### PR TITLE
Backport to python 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ __pycache__/
 .mypy_cache/
 *_env/
 *.pyc
-pytest.ini
 .hypothesis/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This port does not have all of the functionality and features of SpArcFiRe such 
 
 ## Requirements
 
-Currently this requires python 3.12.
+Currently this requires python 3.9 or above.
 The packages used are:
 
 - Pillow
@@ -22,6 +22,8 @@ The packages used are:
 - scipy
 - matplotlib (only if using CLI)
 - rich (only if using CLI)
+- pytest (for testing)
+- hypothesis (for testing)
 
 ## Interface
 

--- a/pyarcfire/arc/fit.py
+++ b/pyarcfire/arc/fit.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 import functools
 import logging
-from typing import Sequence
+from typing import Optional, Sequence
 
 # External libraries
 import numpy as np
@@ -70,7 +70,7 @@ def fit_spiral_to_image(
     # Check if the cluster revolves more than once
     bad_bounds, _, _, _ = _calculate_bounds(theta)
 
-    inner_region: BoolArray1D | None = None
+    inner_region: Optional[BoolArray1D] = None
 
     # Gap in theta is not large enough to not need multiple revolutions
     # and the cluster does not contain the origin or is not closed around centre
@@ -350,7 +350,7 @@ def __cluster_has_no_endpoints_or_contains_origin(
 
 def identify_inner_and_outer_spiral(
     image: FloatArray2D, shrink_amount: int, max_diagonal_distance: float = 1.5
-) -> BoolArray1D | None:
+) -> Optional[BoolArray1D]:
     num_radii = int(np.ceil(max((image.shape[0], image.shape[1])) / 2))
     num_theta: int = 360
 
@@ -630,10 +630,10 @@ def __split_regions(
     end_indices: IntegerArray1D,
     theta: FloatArray1D,
     theta_bin_centres: FloatArray1D,
-    wrap_data: WrapData | None,
+    wrap_data: Optional[WrapData],
 ) -> tuple[BoolArray1D, BoolArray1D, int]:
     region_lengths = end_indices - start_indices + 1
-    max_region_length: int | None = (
+    max_region_length: Optional[int] = (
         region_lengths.max() if len(region_lengths) > 0 else None
     )
     only_wrap_exists: bool = max_region_length is None
@@ -676,10 +676,10 @@ def __calculate_wrap(
     can_be_single_revolution: BoolArray1D,
     start_indices: IntegerArray1D,
     end_indices: IntegerArray1D,
-) -> tuple[IntegerArray1D, IntegerArray1D, WrapData | None]:
+) -> tuple[IntegerArray1D, IntegerArray1D, Optional[WrapData]]:
     has_wrapped: bool = False
-    wrap_start: int | None = None
-    wrap_end: int | None = None
+    wrap_start: Optional[int] = None
+    wrap_end: Optional[int] = None
     # Region ends but either doesn't start or it wraps
     if len(end_indices) > 0 and (
         len(start_indices) == 0 or start_indices[0] > end_indices[0]
@@ -706,7 +706,7 @@ def __calculate_wrap(
         )
     assert len(start_indices) == len(end_indices)
 
-    wrap_data: WrapData | None = None
+    wrap_data: Optional[WrapData] = None
     if has_wrapped:
         # Last continuous single revolution region is at the beginning, but doesn"t
         # actually wrap around
@@ -783,7 +783,7 @@ def _remove_theta_discontinuities(
 
 def _adjust_theta_for_gap(
     theta: FloatArray1D, image: FloatArray2D, region: BoolArray1D
-) -> FloatArray1D | None:
+) -> Optional[FloatArray1D]:
     row_indices, column_indices = image.nonzero()
     assert len(row_indices) == len(column_indices)
     assert len(region) == len(row_indices)

--- a/pyarcfire/arc/functions.py
+++ b/pyarcfire/arc/functions.py
@@ -1,4 +1,5 @@
 # Standard libraries
+from typing import TypeVar
 
 # External libraries
 import numpy as np
@@ -6,12 +7,13 @@ import numpy as np
 # Internal libraries
 from pyarcfire.definitions import FloatArray1D
 
+T = TypeVar("T", float, FloatArray1D)
 
-def log_spiral[T: (float, FloatArray1D)](
+
+def log_spiral(
     theta: T, offset: float, pitch_angle: float, initial_radius: float, use_modulo: bool
 ) -> T:
     angles = theta - offset
-    # TODO: For single rev, we need to mod but multi rev should not mod
     if use_modulo:
         angles %= 2 * np.pi
     result: T = initial_radius * np.exp(-pitch_angle * angles)  # type:ignore

--- a/pyarcfire/cluster.py
+++ b/pyarcfire/cluster.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 # Standard libraries
 import logging
-from typing import Sequence
+from typing import Sequence, Union
 
 # External libraries
 import numpy as np
@@ -115,7 +115,7 @@ class Cluster:
 @benchmark
 def generate_clusters(
     image: Array2D,
-    similarity_matrix: sparse.csr_matrix | sparse.csc_matrix,
+    similarity_matrix: Union[sparse.csr_matrix, sparse.csc_matrix],
     stop_threshold: float,
     error_ratio_threshold: float = 2.5,
     merge_check_minimum_cluster_size: int = 25,
@@ -241,7 +241,7 @@ def generate_clusters(
 
 
 def _update_similarity_matrix(
-    similarity_matrix: sparse.csr_matrix | sparse.csc_matrix,
+    similarity_matrix: Union[sparse.csr_matrix, sparse.csc_matrix],
     target_idx: int,
     source_idx: int,
 ) -> sparse.csr_matrix:
@@ -327,7 +327,7 @@ def _update_similarity_matrix(
 
 
 def _clear_similarity_matrix_row_column(
-    similarity_matrix: sparse.csr_matrix | sparse.csc_matrix, clear_idx: int
+    similarity_matrix: Union[sparse.csr_matrix, sparse.csc_matrix], clear_idx: int
 ) -> sparse.csr_matrix:
     """Returns the similarity matrix with the row and column at the given index cleared to zero.
 

--- a/pyarcfire/debug_utils.py
+++ b/pyarcfire/debug_utils.py
@@ -4,7 +4,7 @@
 from functools import wraps
 import logging
 import time
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Union
 
 # External libraries
 from matplotlib import pyplot as plt
@@ -44,7 +44,7 @@ def benchmark(func: Callable) -> Callable:
     return wrapper
 
 
-def debug_plot_image(image: Array2D | Sequence[Array2D]) -> None:
+def debug_plot_image(image: Union[Array2D, Sequence[Array2D]]) -> None:
     is_sequence = isinstance(image, list) or isinstance(image, tuple)
     fig = plt.figure()
     axis = fig.add_subplot(111)

--- a/pyarcfire/definitions.py
+++ b/pyarcfire/definitions.py
@@ -3,8 +3,8 @@ Note that despite the type names referencing array shape, this is not reflected 
 the python type system, they are just for hinting to the reader.
 """
 
-# Internal libraries
-from typing import TypeAlias
+# Standard libraries
+from typing import Union
 
 # External libraries
 import numpy as np
@@ -12,24 +12,24 @@ from numpy import typing as npt
 
 
 # 1D Arrays
-FloatArray1D: TypeAlias = npt.NDArray[np.floating]
-IntegerArray1D: TypeAlias = npt.NDArray[np.integer]
-BoolArray1D: TypeAlias = npt.NDArray[np.bool_]
-NumberArray1D: TypeAlias = FloatArray1D | IntegerArray1D
-Array1D: TypeAlias = BoolArray1D | NumberArray1D
+FloatArray1D = npt.NDArray[np.floating]
+IntegerArray1D = npt.NDArray[np.integer]
+BoolArray1D = npt.NDArray[np.bool_]
+NumberArray1D = Union[FloatArray1D, IntegerArray1D]
+Array1D = Union[BoolArray1D, NumberArray1D]
 
 
 # 2D Arrays
-FloatArray2D: TypeAlias = npt.NDArray[np.floating]
-IntegerArray2D: TypeAlias = npt.NDArray[np.integer]
-BoolArray2D: TypeAlias = npt.NDArray[np.bool_]
-NumberArray2D: TypeAlias = FloatArray2D | IntegerArray2D
-Array2D: TypeAlias = BoolArray2D | NumberArray2D
+FloatArray2D = npt.NDArray[np.floating]
+IntegerArray2D = npt.NDArray[np.integer]
+BoolArray2D = npt.NDArray[np.bool_]
+NumberArray2D = Union[FloatArray2D, IntegerArray2D]
+Array2D = Union[BoolArray2D, NumberArray2D]
 
 
 # 3D Arrays
-FloatArray3D: TypeAlias = npt.NDArray[np.floating]
-IntegerArray3D: TypeAlias = npt.NDArray[np.integer]
-BoolArray3D: TypeAlias = npt.NDArray[np.bool_]
-NumberArray3D: TypeAlias = FloatArray3D | IntegerArray3D
-Array3D: TypeAlias = BoolArray3D | NumberArray3D
+FloatArray3D = npt.NDArray[np.floating]
+IntegerArray3D = npt.NDArray[np.integer]
+BoolArray3D = npt.NDArray[np.bool_]
+NumberArray3D = Union[FloatArray3D, IntegerArray3D]
+Array3D = Union[BoolArray3D, NumberArray3D]

--- a/pyarcfire/matrix_utils.py
+++ b/pyarcfire/matrix_utils.py
@@ -1,6 +1,7 @@
 """This module contains utilities regarding matrices."""
 
 # Standard libraries
+from typing import Union
 
 # External libraries
 import numpy as np
@@ -10,7 +11,7 @@ from scipy import sparse
 
 
 def is_sparse_matrix_hollow(
-    matrix: sparse.coo_matrix | sparse.csr_matrix | sparse.csc_matrix,
+    matrix: Union[sparse.coo_matrix, sparse.csr_matrix, sparse.csc_matrix],
 ) -> bool:
     """Utility used to assert that a sparse matrix is hollow i.e. no non-zero values in diagonal.
 
@@ -29,7 +30,7 @@ def is_sparse_matrix_hollow(
 
 
 def is_sparse_matrix_symmetric(
-    matrix: sparse.coo_matrix | sparse.csr_matrix | sparse.csc_matrix,
+    matrix: Union[sparse.coo_matrix, sparse.csr_matrix, sparse.csc_matrix],
 ) -> bool:
     """Utility used to assert that a sparse matrix is symmetric i.e. it is equal to its transpose.
 
@@ -40,7 +41,7 @@ def is_sparse_matrix_symmetric(
 
     Returns
     -------
-    is_symmetric: bool
+    is_symmetric : bool
         Returns true if the matrix is symmetric otherwise false.
     """
     is_symmetric = (matrix - matrix.transpose()).count_nonzero() == 0  # type:ignore

--- a/pyarcfire/spiral.py
+++ b/pyarcfire/spiral.py
@@ -64,13 +64,12 @@ class ClusterSpiralResult:
 
     def dump(self, path: str) -> None:
         extension = os.path.splitext(path)[1].lstrip(".")
-        match extension:
-            case "npy":
-                np.save(path, self._cluster_masks)
-            case "mat":
-                scipy.io.savemat(path, {"image": self._cluster_masks})
-            case _:
-                pass
+        if extension == "npy":
+            np.save(path, self._cluster_masks)
+        elif extension == "mat":
+            scipy.io.savemat(path, {"image": self._cluster_masks})
+        else:
+            log.warning(f"Unknown extension {extension}. Not dumping.")
 
 
 @benchmark

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests


### PR DESCRIPTION
Remove usages of python 3.10+ features like type hints and match case. This now allows pyarcfire to be run on python versions that are at least 3.9.