### PR TITLE
Change from using sparse matrices to sparse arrays

### DIFF
--- a/pyarcfire/cluster.py
+++ b/pyarcfire/cluster.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -20,6 +20,52 @@ log: logging.Logger = logging.getLogger(__name__)
 
 
 FloatType = np.float32
+
+SparseMatrix = TypeVar(
+    "SparseMatrix",
+    sparse.coo_array,
+    sparse.bsr_array,
+    sparse.csc_array,
+    sparse.csr_array,
+    sparse.dia_array,
+    sparse.dok_array,
+    sparse.lil_array,
+    sparse.coo_matrix,
+    sparse.bsr_matrix,
+    sparse.csc_matrix,
+    sparse.csr_matrix,
+    sparse.dia_matrix,
+    sparse.dok_matrix,
+    sparse.lil_matrix,
+)
+SparseArray = TypeVar(
+    "SparseArray",
+    sparse.coo_array,
+    sparse.bsr_array,
+    sparse.csc_array,
+    sparse.csr_array,
+    sparse.dia_array,
+    sparse.dok_array,
+    sparse.lil_array,
+)
+SparseMatrixSupportsIndex = TypeVar(
+    "SparseMatrixSupportsIndex",
+    sparse.csc_array,
+    sparse.csr_array,
+    sparse.dok_array,
+    sparse.lil_array,
+    sparse.csc_matrix,
+    sparse.csr_matrix,
+    sparse.dok_matrix,
+    sparse.lil_matrix,
+)
+SparseArraySupportsIndex = TypeVar(
+    "SparseArraySupportsIndex",
+    sparse.csc_array,
+    sparse.csr_array,
+    sparse.dok_array,
+    sparse.lil_array,
+)
 
 
 @dataclass
@@ -41,7 +87,7 @@ class Cluster:
 
         Parameters
         ----------
-        points : Sequence[int]
+        points : Iterable[int]
             The points the cluster consists of.
         """
         self._points: list[int] = list(points)
@@ -132,7 +178,7 @@ class Cluster:
 @benchmark
 def generate_clusters(
     image: NDArray[FloatType],
-    similarity_matrix: sparse.csr_array,
+    input_similarity_matrix: SparseArray,
     stop_threshold: float,
     error_ratio_threshold: float,
     merge_check_minimum_cluster_size: int,
@@ -149,7 +195,7 @@ def generate_clusters(
     ----------
     image : NDArray[FloatType]
         The image to find clusters in.
-    similarity_matrix : sparse.coo_array
+    similarity_matrix : SparseArray
         The similarity matrix representing pixel similarities in the image.
     stop_threshold : float
         The minimum similarity value where cluster merging can happen.
@@ -172,9 +218,11 @@ def generate_clusters(
         raise ValueError("The image must be a 2D array!")
 
     # Verify symmetry and implicitly squareness
-    if not is_sparse_matrix_symmetric(similarity_matrix):
+    if not is_sparse_matrix_symmetric(input_similarity_matrix):
         raise ValueError("Similarity matrix must be symmetric!")
 
+    # Change to an index that supports indexing
+    similarity_matrix: sparse.csr_array = input_similarity_matrix.tocsr()
     num_pixels_from_matrix = similarity_matrix.shape[0]
     num_pixels_from_image = image.shape[0] * image.shape[1]
     if num_pixels_from_image != num_pixels_from_matrix:
@@ -191,8 +239,7 @@ def generate_clusters(
     merge_stop_count: int = 0
 
     # Indices of pixels which have a non-zero similarity with another pixel
-    points = similarity_matrix.sum(axis=0).nonzero()[0]  # type:ignore
-    points = cast(NDArray[np.int64], points)
+    points = np.flatnonzero(similarity_matrix.sum(axis=0))
     # Assign a cluster to each pixel with non-zero similarity to another pixel
     clusters = {idx: Cluster([idx]) for idx in points}
 
@@ -205,7 +252,7 @@ def generate_clusters(
         second_idx = int(unraveled_idx[1])
 
         # Leave loop if similarity value is below the stop threshold
-        value = float(similarity_matrix[first_idx, second_idx])  # type:ignore
+        value = similarity_matrix[first_idx, second_idx]
         if value < stop_threshold:
             break
 
@@ -301,21 +348,16 @@ def _update_similarity_matrix(
         The matrix with its rows and columns updated with the new similarity values.
     """
     # Merged cluster similarity is the maximum possible similarity from the set of cluster points
-    old_similarity_values: sparse.csr_array = cast(
-        sparse.csr_array, similarity_matrix[[target_idx], :]
-    )
+    old_similarity_values = similarity_matrix[[target_idx], :]
     # The updated values max(Ti, Si)
-    new_similarity_values: sparse.csr_array = cast(
-        sparse.csr_array,
-        similarity_matrix[[target_idx], :].maximum(similarity_matrix[[source_idx], :]),
+    new_similarity_values = similarity_matrix[[target_idx], :].maximum(
+        similarity_matrix[[source_idx], :]
     )
     # Remove self-similarity
     new_similarity_values[0, [target_idx]] = 0
 
     # AIM: Construct matrix such that when added, the target row and column is updated to the desired values
-    add_matrix_values: sparse.csr_array = cast(
-        sparse.csr_array, new_similarity_values - old_similarity_values
-    )
+    add_matrix_values = new_similarity_values - old_similarity_values
     # The target row/column already has the right similarity values
     updated_matrix: sparse.csr_array
     if add_matrix_values.count_nonzero() == 0:
@@ -341,18 +383,18 @@ def _update_similarity_matrix(
             shape=similarity_matrix.shape,
         )
         # Add matrix
-        updated_matrix = cast(sparse.csr_array, similarity_matrix + add_matrix)
+        updated_matrix = similarity_matrix + add_matrix
     return updated_matrix
 
 
 def _clear_similarity_matrix_row_column(
-    similarity_matrix: sparse.csr_array, clear_idx: int
-) -> sparse.csr_array:
+    similarity_matrix: SparseMatrixSupportsIndex, clear_idx: int
+) -> SparseMatrixSupportsIndex:
     """Returns the similarity matrix with the row and column at the given index cleared to zero.
 
     Parameters
     ----------
-    similarity_matrix : sparse.csr_array
+    similarity_matrix : SparseMatrixSupportsIndex
         The similarity matrix to update.
     clear_idx: int
         The index of the row and column to clear/zero.
@@ -363,11 +405,8 @@ def _clear_similarity_matrix_row_column(
         The matrix with one of its rows and columns cleared.
     """
     # Construct matrix such that when added the target row and column are cleared
-    values = get_nonzero_values(similarity_matrix.getrow(clear_idx))  # type:ignore
-    indices: NDArray[np.int32] = cast(
-        NDArray[np.int32],
-        similarity_matrix.getrow(clear_idx).nonzero()[1],  # type:ignore
-    )
+    values = get_nonzero_values(similarity_matrix[[clear_idx], :])
+    indices: NDArray[np.int32] = similarity_matrix[[clear_idx], :].nonzero()[1]
     num_nonzero = len(indices)
     clear_matrix_row_indices = np.tile(indices, 2)
     clear_matrix_row_indices[num_nonzero:] = clear_idx
@@ -385,6 +424,6 @@ def _clear_similarity_matrix_row_column(
     )
 
     # Add matrix
-    updated_matrix = cast(sparse.csr_array, similarity_matrix - clear_matrix)
+    updated_matrix = similarity_matrix - clear_matrix
 
     return updated_matrix

--- a/pyarcfire/matrix_utils.py
+++ b/pyarcfire/matrix_utils.py
@@ -26,12 +26,10 @@ SparseMatrix = TypeVar(
 
 SparseMatrixSupportsIndex = TypeVar(
     "SparseMatrixSupportsIndex",
-    sparse.bsr_array,
     sparse.csc_array,
     sparse.csr_array,
     sparse.dok_array,
     sparse.lil_array,
-    sparse.bsr_matrix,
     sparse.csc_matrix,
     sparse.csr_matrix,
     sparse.dok_matrix,

--- a/pyarcfire/matrix_utils.py
+++ b/pyarcfire/matrix_utils.py
@@ -1,6 +1,6 @@
 """This module contains utilities regarding matrices."""
 
-from typing import cast, TypeVar
+from typing import TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -67,7 +67,7 @@ def is_sparse_matrix_symmetric(matrix: SparseMatrix) -> bool:
     is_symmetric : bool
         Returns true if the matrix is symmetric otherwise false.
     """
-    is_symmetric = cast(bool, (matrix - matrix.transpose()).count_nonzero() == 0)
+    is_symmetric = (matrix - matrix.transpose()).count_nonzero() == 0
     return is_symmetric
 
 

--- a/pyarcfire/matrix_utils.py
+++ b/pyarcfire/matrix_utils.py
@@ -1,20 +1,50 @@
 """This module contains utilities regarding matrices."""
 
-from typing import Union, cast
+from typing import cast, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
 from scipy import sparse
 
+SparseMatrix = TypeVar(
+    "SparseMatrix",
+    sparse.coo_array,
+    sparse.bsr_array,
+    sparse.csc_array,
+    sparse.csr_array,
+    sparse.dia_array,
+    sparse.dok_array,
+    sparse.lil_array,
+    sparse.coo_matrix,
+    sparse.bsr_matrix,
+    sparse.csc_matrix,
+    sparse.csr_matrix,
+    sparse.dia_matrix,
+    sparse.dok_matrix,
+    sparse.lil_matrix,
+)
 
-def is_sparse_matrix_hollow(
-    matrix: sparse.coo_array,
-) -> bool:
+SparseMatrixSupportsIndex = TypeVar(
+    "SparseMatrixSupportsIndex",
+    sparse.bsr_array,
+    sparse.csc_array,
+    sparse.csr_array,
+    sparse.dok_array,
+    sparse.lil_array,
+    sparse.bsr_matrix,
+    sparse.csc_matrix,
+    sparse.csr_matrix,
+    sparse.dok_matrix,
+    sparse.lil_matrix,
+)
+
+
+def is_sparse_matrix_hollow(matrix: SparseMatrix) -> bool:
     """Utility used to assert that a sparse matrix is hollow i.e. no non-zero values in diagonal.
 
     Parameters
     ----------
-    matrix : sparse.coo_matrix | sparse.csr_matrix | sparse.csc_matrix
+    matrix : SparseMatrix
         The matrix to assert about.
 
     Returns
@@ -26,20 +56,12 @@ def is_sparse_matrix_hollow(
     return is_hollow
 
 
-def is_sparse_matrix_symmetric(
-    matrix: Union[
-        sparse.coo_matrix,
-        sparse.csr_matrix,
-        sparse.csc_matrix,
-        sparse.coo_array,
-        sparse.csr_array,
-    ],
-) -> bool:
+def is_sparse_matrix_symmetric(matrix: SparseMatrix) -> bool:
     """Utility used to assert that a sparse matrix is symmetric i.e. it is equal to its transpose.
 
     Parameters
     ----------
-    matrix : sparse.coo_matrix | sparse.csr_matrix | sparse.csc_matrix
+    matrix : SparseMatrix
         The matrix to assert about.
 
     Returns
@@ -47,9 +69,21 @@ def is_sparse_matrix_symmetric(
     is_symmetric : bool
         Returns true if the matrix is symmetric otherwise false.
     """
-    is_symmetric = cast(bool, (matrix - matrix.transpose()).count_nonzero() == 0)  # type:ignore
+    is_symmetric = cast(bool, (matrix - matrix.transpose()).count_nonzero() == 0)
     return is_symmetric
 
 
-def get_nonzero_values(matrix: sparse.csr_array) -> NDArray[np.float32]:
-    return np.asarray(matrix[matrix.nonzero()], dtype=np.float32).flatten()  # type:ignore
+def get_nonzero_values(matrix: SparseMatrixSupportsIndex) -> NDArray[np.float32]:
+    """Returns all non-zero values as a flat array.
+
+    Parameters
+    ----------
+    matrix : SparseMatrixSupportsIndex
+        The matrix to assert about.
+
+    Returns
+    -------
+    NDArray[np.float32]
+        The non-zero values.
+    """
+    return np.asarray(matrix[matrix.nonzero()], dtype=np.float32).flatten()

--- a/pyarcfire/matrix_utils.py
+++ b/pyarcfire/matrix_utils.py
@@ -8,7 +8,7 @@ from scipy import sparse
 
 
 def is_sparse_matrix_hollow(
-    matrix: sparse.coo_matrix,
+    matrix: sparse.coo_array,
 ) -> bool:
     """Utility used to assert that a sparse matrix is hollow i.e. no non-zero values in diagonal.
 
@@ -27,7 +27,13 @@ def is_sparse_matrix_hollow(
 
 
 def is_sparse_matrix_symmetric(
-    matrix: Union[sparse.coo_matrix, sparse.csr_matrix, sparse.csc_matrix],
+    matrix: Union[
+        sparse.coo_matrix,
+        sparse.csr_matrix,
+        sparse.csc_matrix,
+        sparse.coo_array,
+        sparse.csr_array,
+    ],
 ) -> bool:
     """Utility used to assert that a sparse matrix is symmetric i.e. it is equal to its transpose.
 
@@ -45,5 +51,5 @@ def is_sparse_matrix_symmetric(
     return is_symmetric
 
 
-def get_nonzero_values(matrix: sparse.csr_matrix) -> NDArray[np.float32]:
+def get_nonzero_values(matrix: sparse.csr_array) -> NDArray[np.float32]:
     return np.asarray(matrix[matrix.nonzero()], dtype=np.float32).flatten()  # type:ignore

--- a/pyarcfire/similarity.py
+++ b/pyarcfire/similarity.py
@@ -31,7 +31,7 @@ class GenerateSimilarityMatrixSettings:
 @benchmark
 def generate_similarity_matrix(
     orientation: OrientationField, similarity_cutoff: float
-) -> sparse.coo_matrix:
+) -> sparse.coo_array:
     """Generates a sparse pixel-to-pixel similarity matrix from an orientation field.
 
     Parameters
@@ -44,7 +44,7 @@ def generate_similarity_matrix(
 
     Returns
     -------
-    similarity_matrix : sparse.coo_matrix
+    similarity_matrix : sparse.coo_array
         The similarity matrix expressed as a sparse matrix.
 
     Notes
@@ -60,7 +60,7 @@ def generate_similarity_matrix(
         num_vecs,
     ) = _calculate_pixel_similarities(orientation, similarity_cutoff)
 
-    similarity_matrix = sparse.coo_matrix(
+    similarity_matrix = sparse.coo_array(
         (similarity_values, (root_indices, child_indices)), shape=(num_vecs, num_vecs)
     )
     assert is_sparse_matrix_hollow(similarity_matrix)

--- a/pyarcfire/spiral.py
+++ b/pyarcfire/spiral.py
@@ -1,12 +1,10 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import cast
 
 import numpy as np
 import scipy.io
 from numpy.typing import NDArray
-from scipy import sparse
 from skimage import filters
 
 from .cluster import GenerateClustersSettings, generate_clusters
@@ -157,7 +155,7 @@ def detect_spirals_in_image(
     log.info("[cyan]PROGRESS[/cyan]: Generating clusters...")
     cluster_arrays = generate_clusters(
         image,
-        cast(sparse.csr_array, matrix.tocsr()),
+        matrix.tocsr(),
         stop_threshold=generate_clusters_settings.stop_threshold,
         error_ratio_threshold=generate_clusters_settings.error_ratio_threshold,
         merge_check_minimum_cluster_size=generate_clusters_settings.merge_check_minimum_cluster_size,

--- a/pyarcfire/spiral.py
+++ b/pyarcfire/spiral.py
@@ -1,10 +1,12 @@
 import logging
 import os
 from dataclasses import dataclass
+from typing import cast
 
 import numpy as np
-from numpy.typing import NDArray
 import scipy.io
+from numpy.typing import NDArray
+from scipy import sparse
 from skimage import filters
 
 from .cluster import GenerateClustersSettings, generate_clusters
@@ -155,7 +157,7 @@ def detect_spirals_in_image(
     log.info("[cyan]PROGRESS[/cyan]: Generating clusters...")
     cluster_arrays = generate_clusters(
         image,
-        matrix.tocsr(),
+        cast(sparse.csr_array, matrix.tocsr()),
         stop_threshold=generate_clusters_settings.stop_threshold,
         error_ratio_threshold=generate_clusters_settings.error_ratio_threshold,
         merge_check_minimum_cluster_size=generate_clusters_settings.merge_check_minimum_cluster_size,


### PR DESCRIPTION
Scipy is moving to use a sparse array interface compatible with numpy arrays rather than the numpy matrix interface. Therefore it makes sense to use sparse arrays instead of sparse matrices.