### PR TITLE
Add conversion from pixels to user defined units when getting spiral arc coordinates

### DIFF
--- a/pyarcfire/arc/common.py
+++ b/pyarcfire/arc/common.py
@@ -20,13 +20,13 @@ class LogSpiralFitResult(Generic[FloatType]):
     has_multiple_revolutions: bool
 
     def calculate_cartesian_coordinates(
-        self, num_points: int
+        self, num_points: int, pixel_to_distance: float
     ) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
         start_angle = self.offset
         end_angle = start_angle + self.arc_bounds[1]
 
         theta = np.linspace(start_angle, end_angle, num_points, dtype=np.float32)
-        radii = log_spiral(
+        radii = pixel_to_distance * log_spiral(
             theta,
             self.offset,
             self.pitch_angle,

--- a/pyarcfire/arc/common.py
+++ b/pyarcfire/arc/common.py
@@ -20,8 +20,13 @@ class LogSpiralFitResult(Generic[FloatType]):
     has_multiple_revolutions: bool
 
     def calculate_cartesian_coordinates(
-        self, num_points: int, pixel_to_distance: float
+        self,
+        num_points: int,
+        pixel_to_distance: float,
+        *,
+        flip_y: bool = False,
     ) -> tuple[NDArray[np.float32], NDArray[np.float32]]:
+        y_flip_factor: float = 1.0 if not flip_y else -1.0
         start_angle = self.offset
         end_angle = start_angle + self.arc_bounds[1]
 
@@ -34,5 +39,5 @@ class LogSpiralFitResult(Generic[FloatType]):
             use_modulo=not self.has_multiple_revolutions,
         )
         x = np.multiply(radii, np.cos(theta))
-        y = np.multiply(radii, np.sin(theta))
+        y = y_flip_factor * np.multiply(radii, np.sin(theta))
         return (x, y)

--- a/pyarcfire/spiral.py
+++ b/pyarcfire/spiral.py
@@ -153,13 +153,19 @@ class ClusterSpiralResult:
         return self._spiral_cache[cluster_idx]
 
     def get_spirals(
-        self, num_points: int, pixel_to_distance: float
+        self,
+        num_points: int,
+        pixel_to_distance: float,
+        *,
+        flip_y: bool = False,
     ) -> Generator[tuple[NDArray[FloatType], NDArray[FloatType]], None, None]:
         num_clusters: int = self.get_num_clusters()
         for cluster_idx in range(num_clusters):
             spiral_fit = self._get_fit(cluster_idx)
             x, y = spiral_fit.calculate_cartesian_coordinates(
-                num_points, pixel_to_distance
+                num_points,
+                pixel_to_distance,
+                flip_y=flip_y,
             )
             yield x, y
 

--- a/pyarcfire/spiral.py
+++ b/pyarcfire/spiral.py
@@ -134,7 +134,7 @@ class ClusterSpiralResult:
         log.info(f"[yellow]FILESYST[/yellow]: Dumped masks to [yellow]{path}[/yellow]")
 
     def get_spiral_of(
-        self, cluster_idx: int, num_points: int = 100
+        self, cluster_idx: int, num_points: int = 100, pixel_to_distance: float = 1
     ) -> tuple[NDArray[FloatType], NDArray[FloatType]]:
         if cluster_idx not in range(self.get_num_clusters()):
             raise ValueError("Expected a valid cluster index!")
@@ -143,7 +143,7 @@ class ClusterSpiralResult:
             current_array, _ = self.get_cluster_array(cluster_idx)
             self._spiral_cache[cluster_idx] = fit_spiral_to_image(current_array)
         spiral_fit = self._spiral_cache[cluster_idx]
-        x, y = spiral_fit.calculate_cartesian_coordinates(num_points)
+        x, y = spiral_fit.calculate_cartesian_coordinates(num_points, pixel_to_distance)
         return x, y
 
     def _get_fit(self, cluster_idx: int) -> LogSpiralFitResult[FloatType]:
@@ -153,12 +153,14 @@ class ClusterSpiralResult:
         return self._spiral_cache[cluster_idx]
 
     def get_spirals(
-        self, num_points: int
+        self, num_points: int, pixel_to_distance: float
     ) -> Generator[tuple[NDArray[FloatType], NDArray[FloatType]], None, None]:
         num_clusters: int = self.get_num_clusters()
         for cluster_idx in range(num_clusters):
             spiral_fit = self._get_fit(cluster_idx)
-            x, y = spiral_fit.calculate_cartesian_coordinates(num_points)
+            x, y = spiral_fit.calculate_cartesian_coordinates(
+                num_points, pixel_to_distance
+            )
             yield x, y
 
     def get_arc_bounds(self, cluster_idx: int) -> tuple[float, float]:


### PR DESCRIPTION
Before when getting the x, y coordinates of a spiral arc from a ClusterSpiralResult, the units were always in pixel units which makes it hard to properly plot.

This PR adds the ability for the user to specify the conversion factor so [factor] = (user_unit) / pixel.
Additionally adds the ability to flip the y coordinate of the spiral arc coordinates to help in plotting as well.