### PR TITLE
Fix a few glaring bugs

### DIFF
--- a/pyarcfire/merge.py
+++ b/pyarcfire/merge.py
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
     FloatType = TypeVar("FloatType", np.float32, np.float64)
 
 
-def calculate_arc_merge_error(first_cluster_array: NDArray[FloatType], second_cluster_array: NDArray[FloatType]) -> float:
+def calculate_arc_merge_error(
+    first_cluster_array: NDArray[FloatType], second_cluster_array: NDArray[FloatType]
+) -> float:
     """Calculate the arc merge error ratio for two clusters.
 
     This is a measure of how well the merged cluster of the two clusters given fit to a log spiral
@@ -24,9 +26,9 @@ def calculate_arc_merge_error(first_cluster_array: NDArray[FloatType], second_cl
 
     Parameters
     ----------
-    first_cluster_array : Array2D
+    first_cluster_array : NDArray[FloatType]
         The first cluster in the form of an array.
-    second_cluster_array : Array2D
+    second_cluster_array : NDArray[FloatType]
         The second cluster in the form of an array.
 
     Returns
@@ -43,14 +45,14 @@ def calculate_arc_merge_error(first_cluster_array: NDArray[FloatType], second_cl
         raise ValueError(msg)
     total_sum = first_sum + second_sum
     # Adjust weights
-    first_cluster_array *= total_sum / first_sum
-    second_cluster_array *= total_sum / second_sum
+    first_reweighted_array = first_cluster_array * total_sum / first_sum
+    second_reweighted_array = second_cluster_array * total_sum / second_sum
 
     # Fit spirals to each cluster individually
-    first_fit = fit_spiral_to_image(first_cluster_array)
-    second_fit = fit_spiral_to_image(second_cluster_array)
+    first_fit = fit_spiral_to_image(first_reweighted_array)
+    second_fit = fit_spiral_to_image(second_reweighted_array)
 
-    combined_cluster_array = first_cluster_array + second_cluster_array
+    combined_cluster_array = first_reweighted_array + second_reweighted_array
     # Fit a spiral to both clusters at the same time
     first_merged_fit = fit_spiral_to_image(
         combined_cluster_array,
@@ -62,7 +64,7 @@ def calculate_arc_merge_error(first_cluster_array: NDArray[FloatType], second_cl
     )
     first_fit_is_better = first_merged_fit.total_error <= second_merged_fit.total_error
     merged_fit = first_merged_fit if first_fit_is_better else second_merged_fit
-    first_cluster_indices = (first_cluster_array > 0)[combined_cluster_array > 0]
+    first_cluster_indices = (first_reweighted_array > 0)[combined_cluster_array > 0]
     # Get the error of the merged spiral for each individual cluster
     first_cluster_errors = merged_fit.errors[first_cluster_indices].sum()
     second_cluster_errors = merged_fit.errors[~first_cluster_indices].sum()

--- a/pyarcfire/spiral.py
+++ b/pyarcfire/spiral.py
@@ -14,16 +14,28 @@ from skimage import filters
 from pyarcfire.arc.utils import get_polar_coordinates
 
 from .arc import LogSpiralFitResult, fit_spiral_to_image
-from .cluster import DEFAULT_CLUSTER_SETTINGS, GenerateClustersSettings, generate_clusters
+from .cluster import (
+    DEFAULT_CLUSTER_SETTINGS,
+    GenerateClustersSettings,
+    generate_clusters,
+)
 from .debug_utils import benchmark
-from .merge_fit import DEFAULT_MERGE_CLUSTER_BY_FIT_SETTINGS, MergeClustersByFitSettings, merge_clusters_by_fit
+from .merge_fit import (
+    DEFAULT_MERGE_CLUSTER_BY_FIT_SETTINGS,
+    MergeClustersByFitSettings,
+    merge_clusters_by_fit,
+)
 from .orientation import (
     DEFAULT_ORIENTATION_FIELD_SETTINGS,
     GenerateOrientationFieldSettings,
     OrientationField,
     generate_orientation_fields,
 )
-from .similarity import DEFAULT_SIMILARITY_MATRIX_SETTINGS, GenerateSimilarityMatrixSettings, generate_similarity_matrix
+from .similarity import (
+    DEFAULT_SIMILARITY_MATRIX_SETTINGS,
+    GenerateSimilarityMatrixSettings,
+    generate_similarity_matrix,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
@@ -100,15 +112,26 @@ class ClusterSpiralResult:
         self._cluster_masks: NDArray[FloatType] = cluster_masks
         self._field: OrientationField = field
         self._sizes: tuple[int, ...] = tuple(
-            [np.count_nonzero(self._cluster_masks[:, :, idx]) for idx in range(self._cluster_masks.shape[2])],
+            [
+                np.count_nonzero(self._cluster_masks[:, :, idx])
+                for idx in range(self._cluster_masks.shape[2])
+            ],
         )
 
         # Settings
         self._unsharp_mask_settings: UnsharpMaskSettings = unsharp_mask_settings
-        self._orientation_field_settings: GenerateOrientationFieldSettings = orientation_field_settings
-        self._similarity_matrix_settings: GenerateSimilarityMatrixSettings = similarity_matrix_settings
-        self._generate_cluster_settings: GenerateClustersSettings = generate_cluster_settings
-        self._merge_clusters_by_fit_settings: MergeClustersByFitSettings = merge_clusters_by_fit_settings
+        self._orientation_field_settings: GenerateOrientationFieldSettings = (
+            orientation_field_settings
+        )
+        self._similarity_matrix_settings: GenerateSimilarityMatrixSettings = (
+            similarity_matrix_settings
+        )
+        self._generate_cluster_settings: GenerateClustersSettings = (
+            generate_cluster_settings
+        )
+        self._merge_clusters_by_fit_settings: MergeClustersByFitSettings = (
+            merge_clusters_by_fit_settings
+        )
 
         # Cache
         self._spiral_cache: dict[int, LogSpiralFitResult[FloatType]] = {}
@@ -244,9 +267,14 @@ class ClusterSpiralResult:
         elif extension == "mat":
             scipy.io.savemat(path, {"image": self._cluster_masks})
         else:
-            log.warning("[yellow]FILESYST[/yellow]: Can not dump due to unknown extension [yellow]%s[/yellow]", extension)
+            log.warning(
+                "[yellow]FILESYST[/yellow]: Can not dump due to unknown extension [yellow]%s[/yellow]",
+                extension,
+            )
             return
-        log.info("[yellow]FILESYST[/yellow]: Dumped masks to [yellow]%s[/yellow]", extension)
+        log.info(
+            "[yellow]FILESYST[/yellow]: Dumped masks to [yellow]%s[/yellow]", extension
+        )
 
     def get_spiral_of(
         self,
@@ -285,7 +313,9 @@ class ClusterSpiralResult:
             current_array, _ = self.get_cluster_array(cluster_idx)
             self._spiral_cache[cluster_idx] = fit_spiral_to_image(current_array)
         spiral_fit = self._spiral_cache[cluster_idx]
-        x, y = spiral_fit.calculate_cartesian_coordinates(num_points, pixel_to_distance, flip_y=flip_y)
+        x, y = spiral_fit.calculate_cartesian_coordinates(
+            num_points, pixel_to_distance, flip_y=flip_y
+        )
         return x, y
 
     def _get_fit(self, cluster_idx: int) -> LogSpiralFitResult[FloatType]:
@@ -412,7 +442,9 @@ def detect_spirals_in_image(
 
     """
     # Unsharp phase
-    unsharp_image = filters.unsharp_mask(image, radius=unsharp_mask_settings.radius, amount=unsharp_mask_settings.amount)
+    unsharp_image = filters.unsharp_mask(
+        image, radius=unsharp_mask_settings.radius, amount=unsharp_mask_settings.amount
+    )
 
     # Generate orientation fields
     log.info("[cyan]PROGRESS[/cyan]: Generating orientation field...")
@@ -426,7 +458,9 @@ def detect_spirals_in_image(
 
     # Generate similarity matrix
     log.info("[cyan]PROGRESS[/cyan]: Generating similarity matrix...")
-    matrix = generate_similarity_matrix(field, similarity_matrix_settings.similarity_cutoff)
+    matrix = generate_similarity_matrix(
+        field, similarity_matrix_settings.similarity_cutoff
+    )
     log.info("[cyan]PROGRESS[/cyan]: Done generating similarity matrix.")
 
     # Merge clusters via HAC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,10 @@ cli = [
     "Pillow",
     "rich>=4.2.1",
 ]
+test = [
+    "pytest",
+    "hypothesis",
+]
 
 [project.urls]
 Source = "https://github.com/pavyamsiri/pyarcfire.git"


### PR DESCRIPTION
The bugs are as follows:

1. As use_modulo is now a keyword-only argument, we must change the call to least_squares to include kwargs.
2. In merge.py, the input arrays were being mutated by accident.
3. In merge_fit.py, a previous refactor forgot to change subsequent calls to the now changed data structure.
    - I changed the data structure again to just a list of cluster arrays which should be simpler.
Additional formatting fixes and adding test dependencies.

Last thing, I added a different normalisation scheme as well. If the input image has negative values I apply Normalize instead of LogNorm.
